### PR TITLE
stream_insertion_operator_deprecation_fix

### DIFF
--- a/test/test_batchtracking.cpp
+++ b/test/test_batchtracking.cpp
@@ -63,12 +63,11 @@ TEST_CASE("Long time")
 
     const vec velocity = {1,1,1,1,1,1,1,1,1};
 
-    mat compBC;
-    compBC << 0.5 << 0.5;
+    mat compBC = {{0.5, 0.5}};
 
     state = BatchTracking::advect(state, 60, compBC, velocity);
 
-    compBC << 1.0 << 1.0;
+    compBC = {{1.0, 1.0}};
     state = BatchTracking::advect(state, 60, compBC, velocity);
 
     state = BatchTracking::advect(state, 1000, compBC, velocity);
@@ -92,8 +91,7 @@ TEST_CASE("Exact time")
 
     const vec velocity = arma::zeros<vec>(nGridPoints - 1) + 1;
 
-    mat compBC;
-    compBC << 0.5 << 0.5;
+    mat compBC = {{0.5, 0.5}};
 
     state = BatchTracking::advect(state, 10.0, compBC, velocity);
     auto out = state.sampleToVec();
@@ -101,7 +99,7 @@ TEST_CASE("Exact time")
     CHECK(out.at(1)(0) == 1.0);
     CHECK(out.at(2)(0) == 1.0);
 
-    compBC << 1.0 << 0.5;
+    compBC = {{1.0, 0.5}};
     state = BatchTracking::advect(state, 10.0, compBC, velocity);
     out = state.sampleToVec();
     CHECK(out.at(0)(0) == 1.0);
@@ -148,8 +146,7 @@ TEST_CASE("gridpoints start at != 0")
 
     const vec velocity = arma::zeros<vec>(nGridPoints - 1) + 2;
 
-    mat compBC;
-    compBC << 2 << 2;
+    mat compBC = {{2, 2}};
 
     state = BatchTracking::advect(state, 5.0, compBC, velocity);
     auto out = state.sampleToVec();
@@ -176,8 +173,7 @@ TEST_CASE("zero velocity at inlet")
 
     const vec velocity = arma::zeros<vec>(nGridPoints - 1);
 
-    mat compBC;
-    compBC << 2 << 2;
+    mat compBC = {{2, 2}};
 
     state = BatchTracking::advect(state, 5.0, compBC, velocity);
     vector<vec> out = state.sampleToVec();

--- a/test/test_heat_steadystate.cpp
+++ b/test/test_heat_steadystate.cpp
@@ -85,11 +85,10 @@ TEST_CASE("thermal resistance calculation")
         const PipeWall wall = PipeWall::defaultPipeWall;
         SteadyStateHeatTransfer heat(dia, wall, burial, BurialMedium::soil, fluid);
 
-        vec r;
-        r << dia/2.0
-          << dia/2.0 + wall.layer(0).thickness()
-          << dia/2.0 + wall.layer(0).thickness() + wall.layer(1).thickness()
-          << dia/2.0 + wall.layer(0).thickness() + wall.layer(1).thickness() + wall.layer(2).thickness();
+        vec r = {dia/2.0,
+                 dia/2.0 + wall.layer(0).thickness(),
+                 dia/2.0 + wall.layer(0).thickness() + wall.layer(1).thickness(),
+                 dia/2.0 + wall.layer(0).thickness() + wall.layer(1).thickness() + wall.layer(2).thickness()};
 
         vec lam = {
             wall.layer(0).conductivity(),

--- a/test/test_matrix_equation.cpp
+++ b/test/test_matrix_equation.cpp
@@ -19,11 +19,9 @@ TEST_CASE("MatrixEquation::fillMatrixAndVector")
     uword nEquationsAndVariables = 3;
     cube term_i = zeros<cube>(nGridPoints, nEquations, nVariables);
     cube term_ipp = zeros<cube>(nGridPoints, nEquations, nVariables);
-    mat boundaryConditions;
-    boundaryConditions
-            << 1.0 << 1.0 << endr
-            << 1.0 << 1.0 << endr
-            << 1.0 << 1.0;
+    mat boundaryConditions = {{1.0, 1.0},
+                              {1.0, 1.0},
+                              {1.0, 1.0}};
     BoundaryConditions bc(boundaryConditions);
     bc.setBoundarySettings({"inlet", "outlet", "inlet"});
 

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -65,10 +65,9 @@ TEST_CASE("numerics")
 {
     SUBCASE("arma solve")
     {
-        arma::mat A;
-        A << 1 << 3 << -2 << arma::endr
-          << 3 << 5 << 6 << arma::endr
-          << 2 << 4 << 3;
+        arma::mat A = {{1, 3,-2},
+                       {3, 5, 6},
+                       {2, 4, 3}};
 
         arma::vec b{5, 7, 8};
 
@@ -87,10 +86,9 @@ TEST_CASE("numerics")
 
         arma::vec x1 = utils::tridag(a, b, c, r, a.n_elem);
 
-        arma::mat A;
-        A << b(0) << c(0) << 0    << arma::endr
-          << a(1) << b(1) << c(1) << arma::endr
-          << 0    << a(2) << b(2);
+        arma::mat A = {{b(0), c(0), 0   },
+                       {a(1), b(1), c(1)},
+                       {0   , a(2), b(2)}};
 
         arma::vec x2 = arma::solve(A, r);
 


### PR DESCRIPTION
The stream insertion operator for matrix initialization and assignment in the Armadillo C++ library has been deprecated in version 10.x.